### PR TITLE
Fix the order of the port to redirect Spark UI

### DIFF
--- a/launch_bootcamp.sh
+++ b/launch_bootcamp.sh
@@ -13,6 +13,6 @@ NETWORK=mini_spark_broker_default
 
 # Run jupyter through the Docker
 docker run -it --rm  \
-	-v $PWD:/home/jovyan/work:rw -p 8888:8888 -p 4040:400 \
+	-v $PWD:/home/jovyan/work:rw -p 8888:8888 -p 400:4040 \
 	--network=${NETWORK} -P msb \
 	/usr/local/spark/bin/pyspark --packages ${KFKSTREAM},${KFKSQL}


### PR DESCRIPTION
This PR fix wrong ordering of ports while launching the bootcamp notebook that was preventing the Spark UI to be used.