### PR TITLE
Force aplpy version to 1.1.1 (2.0+ is buggy for FITSFigure)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ confluent-kafka>=0.11.4
 avro-python3
 Cython
 fastavro
-aplpy
+aplpy==1.1.1
 astropy


### PR DESCRIPTION
the method `FITSFigure` is not working properly for recent v2+. This PR forces the version of APLpy to be 1.1.1.